### PR TITLE
Adding kafka stream reading module to arachne

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,6 +8,7 @@ import (
 	"github.com/bmeg/arachne/cmd/load"
 	"github.com/bmeg/arachne/cmd/rdf"
 	"github.com/bmeg/arachne/cmd/server"
+	"github.com/bmeg/arachne/cmd/stream"
 	"github.com/spf13/cobra"
 	"os"
 )
@@ -23,6 +24,7 @@ func init() {
 	RootCmd.AddCommand(server.Cmd)
 	RootCmd.AddCommand(rdf.Cmd)
 	RootCmd.AddCommand(load.Cmd)
+	RootCmd.AddCommand(stream.Cmd)
 	RootCmd.AddCommand(create.Cmd)
 	RootCmd.AddCommand(drop.Cmd)
 	RootCmd.AddCommand(list.Cmd)

--- a/cmd/stream/main.go
+++ b/cmd/stream/main.go
@@ -1,0 +1,136 @@
+package stream
+
+import (
+	//"fmt"
+	"encoding/json"
+	"github.com/bmeg/arachne/aql"
+	//"github.com/bmeg/golib"
+	"github.com/Shopify/sarama"
+	"github.com/golang/protobuf/jsonpb"
+	"github.com/spf13/cobra"
+	"log"
+	"strings"
+)
+
+var kafka string = "localhost:9092"
+var host string = "localhost:9090"
+var graph string = "data"
+var vertexTopic string = "arachne_vertex"
+var edgeTopic string = "arachne_edge"
+
+var Cmd = &cobra.Command{
+	Use:   "stream",
+	Short: "Stream Data into Arachne Server",
+	Long:  ``,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		log.Printf("Streaming Data from %s", kafka)
+		conn, err := aql.Connect(host, true)
+		if err != nil {
+			return err
+		}
+
+		consumer, err := sarama.NewConsumer([]string{kafka}, nil)
+		if err != nil {
+			panic(err)
+		}
+
+		vertexConsumer, err := consumer.ConsumePartition(vertexTopic, 0, sarama.OffsetOldest)
+		edgeConsumer, err := consumer.ConsumePartition(edgeTopic, 0, sarama.OffsetOldest)
+		//timer := time.AfterFunc(5 * time.Second, partitionConsumer.AsyncClose )
+
+		done := make(chan bool)
+
+		go func() {
+			count := 0
+			for msg := range vertexConsumer.Messages() {
+				v := aql.Vertex{}
+				jsonpb.Unmarshal(strings.NewReader(string(msg.Value)), &v)
+				conn.AddVertex(graph, v)
+				count += 1
+				if count%1000 == 0 {
+					log.Printf("Loaded %d vertices", count)
+				}
+			}
+			done <- true
+		}()
+
+		go func() {
+			count := 0
+			for msg := range edgeConsumer.Messages() {
+				//fix from -> src and to -> dst
+				j := map[string]interface{}{}
+				json.Unmarshal(msg.Value, &j)
+
+				if _, ok := j["from"]; ok {
+					j["src"] = j["from"]
+					delete(j, "from")
+				}
+				if _, ok := j["to"]; ok {
+					j["dst"] = j["to"]
+					delete(j, "to")
+				}
+				txt, _ := json.Marshal(j)
+				e := aql.Edge{}
+				jsonpb.Unmarshal(strings.NewReader(string(txt)), &e)
+				//fmt.Printf("%#v\n", e)
+				conn.AddEdge(graph, e)
+				count += 1
+				if count%1000 == 0 {
+					log.Printf("Loaded %d edges", count)
+				}
+			}
+			done <- true
+		}()
+
+		<-done
+		<-done
+
+		/*
+			if vertexFile != "" {
+				log.Printf("Loading %s", vertexFile)
+				reader, err := golib.ReadFileLines(vertexFile)
+				if err != nil {
+					return err
+				}
+				count := 0
+				for line := range reader {
+					v := aql.Vertex{}
+					jsonpb.Unmarshal(strings.NewReader(string(line)), &v)
+					conn.AddVertex(graph, v)
+					count += 1
+					if count%1000 == 0 {
+						log.Printf("Loaded %d vertices", count)
+					}
+				}
+			}
+			if edgeFile != "" {
+				log.Printf("Loading %s", edgeFile)
+				reader, err := golib.ReadFileLines(edgeFile)
+				if err != nil {
+					return err
+				}
+				count := 0
+				for line := range reader {
+					e := aql.Edge{}
+					jsonpb.Unmarshal(strings.NewReader(string(line)), &e)
+					conn.AddEdge(graph, e)
+					count += 1
+					if count%1000 == 0 {
+						log.Printf("Loaded %d edges", count)
+					}
+				}
+			}
+		*/
+
+		return nil
+	},
+}
+
+func init() {
+	flags := Cmd.Flags()
+	flags.StringVar(&kafka, "kafka", "localhost:9092", "Kafka Server")
+	flags.StringVar(&host, "host", "localhost:9090", "Arachne Server")
+	flags.StringVar(&graph, "graph", "data", "Graph")
+	flags.StringVar(&vertexTopic, "vertex", "arachne_vertex", "Vertex File")
+	flags.StringVar(&edgeTopic, "edge", "arachne_vertex", "Edge File")
+}

--- a/cmd/stream/main.go
+++ b/cmd/stream/main.go
@@ -81,47 +81,8 @@ var Cmd = &cobra.Command{
 			}
 			done <- true
 		}()
-
 		<-done
 		<-done
-
-		/*
-			if vertexFile != "" {
-				log.Printf("Loading %s", vertexFile)
-				reader, err := golib.ReadFileLines(vertexFile)
-				if err != nil {
-					return err
-				}
-				count := 0
-				for line := range reader {
-					v := aql.Vertex{}
-					jsonpb.Unmarshal(strings.NewReader(string(line)), &v)
-					conn.AddVertex(graph, v)
-					count += 1
-					if count%1000 == 0 {
-						log.Printf("Loaded %d vertices", count)
-					}
-				}
-			}
-			if edgeFile != "" {
-				log.Printf("Loading %s", edgeFile)
-				reader, err := golib.ReadFileLines(edgeFile)
-				if err != nil {
-					return err
-				}
-				count := 0
-				for line := range reader {
-					e := aql.Edge{}
-					jsonpb.Unmarshal(strings.NewReader(string(line)), &e)
-					conn.AddEdge(graph, e)
-					count += 1
-					if count%1000 == 0 {
-						log.Printf("Loaded %d edges", count)
-					}
-				}
-			}
-		*/
-
 		return nil
 	},
 }

--- a/mongo/convert.go
+++ b/mongo/convert.go
@@ -1,7 +1,7 @@
 package mongo
 
 import (
-	"fmt"
+	//"fmt"
 	"github.com/bmeg/arachne/aql"
 	"github.com/bmeg/arachne/protoutil"
 	"gopkg.in/mgo.v2/bson"
@@ -15,7 +15,7 @@ func PackVertex(v aql.Vertex) map[string]interface{} {
 	if v.Properties != nil {
 		p = protoutil.AsMap(v.Properties)
 	}
-	fmt.Printf("proto:%s\nmap:%s\n", v.Properties, p)
+	//fmt.Printf("proto:%s\nmap:%s\n", v.Properties, p)
 	return map[string]interface{}{
 		"_id":        v.Gid,
 		"label":      v.Label,


### PR DESCRIPTION
Adds a Kafka stream reader program that looks for json encoded AQL messages in topics and then pushes them to a arachne server