### PR TITLE
Adding stack timing to query engine

### DIFF
--- a/gdbi/interface.go
+++ b/gdbi/interface.go
@@ -88,5 +88,3 @@ type EdgeFilter func(edge aql.Edge) bool
 type PipeRequest struct {
 	LoadProperties bool
 }
-
-type GraphPipe func(ctx context.Context) chan Traveler

--- a/mongo/convert.go
+++ b/mongo/convert.go
@@ -62,7 +62,9 @@ func UnpackVertex(i map[string]interface{}) aql.Vertex {
 	o := aql.Vertex{}
 	o.Gid = i["_id"].(string)
 	o.Label = i["label"].(string)
-	o.Properties = protoutil.AsStruct(i["properties"].(map[string]interface{}))
+	if p, ok := i["properties"]; ok {
+		o.Properties = protoutil.AsStruct(p.(map[string]interface{}))
+	}
 	return o
 }
 


### PR DESCRIPTION
This PR adds wrappers around the pipe invocation to capture timing info. At the end of the query, every phase reports back total time.