### PR TITLE
cmd: remove debug lines

### DIFF
--- a/jsengine/evaluate.go
+++ b/jsengine/evaluate.go
@@ -18,7 +18,6 @@ type genfunc func(string, []string) (JSEngine, error)
 var engines map[string]genfunc = make(map[string]genfunc)
 
 func AddEngine(name string, gen genfunc) bool {
-	log.Printf("Adding %s JS engine", name)
 	engines[name] = gen
 	return true
 }


### PR DESCRIPTION
Examples:
```
arachne list
2017/12/22 19:35:51 Adding goja JS engine
2017/12/22 19:35:51 Adding otto JS engine
bash
test-drive
```

```
arachne
2017/12/22 19:35:50 Adding goja JS engine
2017/12/22 19:35:50 Adding otto JS engine
Usage:
  arachne [command]

Available Commands:
  bash
  create      Create Graph on Arachne Server
  drop        Drop Graph on Arachne Server
  dump        Dump Data on Arachne Server
```

It's weird to have these debug lines printed for all commands, especially `list`.