### PR TITLE
database: change default database name to arachne

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -57,7 +57,7 @@ func init() {
 	flags := Cmd.Flags()
 	flags.StringVar(&httpPort, "port", "8000", "HTTP Port")
 	flags.StringVar(&rpcPort, "rpc", "9090", "TCP+RPC Port")
-	flags.StringVar(&dbPath, "db", "graph_db", "DB Path")
+	flags.StringVar(&dbPath, "db", "arachne", "DB Path")
 	flags.StringVar(&mongoURL, "mongo", "", "Mongo URL")
 	flags.StringVar(&boltPath, "bolt", "", "Bolt DB Path")
 	flags.StringVar(&rocksPath, "rocks", "", "RocksDB Path")


### PR DESCRIPTION
"arachne" is a better default because it's more recognizable and obvious.