### PR TITLE
aql/go: NewQuery

### DIFF
--- a/aql/query.go
+++ b/aql/query.go
@@ -1,0 +1,87 @@
+package aql
+
+import (
+	"bytes"
+	"encoding/json"
+	"github.com/bmeg/arachne/protoutil"
+	"github.com/golang/protobuf/jsonpb"
+)
+
+// Query helps build graph queries.
+type Query struct {
+	*GraphQuery
+}
+
+// NewQuery returns a new query object.
+func NewQuery(graph string) *Query {
+	return &Query{
+		&GraphQuery{
+			Graph: graph,
+		},
+	}
+}
+
+func (q *Query) with(st *GraphStatement) *Query {
+	nq := NewQuery(q.GraphQuery.Graph)
+	copy(q.GraphQuery.Query, nq.GraphQuery.Query)
+	nq.GraphQuery.Query = append(nq.GraphQuery.Query, st)
+	return nq
+}
+
+// V adds a vertex selection step to the query
+func (q *Query) V(id ...string) *Query {
+	vlist := protoutil.AsListValue(id)
+	return q.with(&GraphStatement{&GraphStatement_V{vlist}})
+}
+
+// E adds a edge selection step to the query
+func (q *Query) E(id ...string) *Query {
+	if len(id) > 0 {
+		return q.with(&GraphStatement{&GraphStatement_E{id[0]}})
+	}
+	return q.with(&GraphStatement{&GraphStatement_E{}})
+}
+
+// Out follows outgoing edges to adjacent vertex
+func (q *Query) Out(label ...string) *Query {
+	vlist := protoutil.AsListValue(label)
+	return q.with(&GraphStatement{&GraphStatement_Out{vlist}})
+}
+
+// OutEdge moves to outgoing edge
+func (q *Query) OutEdge(label ...string) *Query {
+	vlist := protoutil.AsListValue(label)
+	return q.with(&GraphStatement{&GraphStatement_OutEdge{vlist}})
+}
+
+// HasLabel filters elements based on label
+func (q *Query) HasLabel(id ...string) *Query {
+	idList := protoutil.AsListValue(id)
+	return q.with(&GraphStatement{&GraphStatement_HasLabel{idList}})
+}
+
+// As marks current elements with tag
+func (q *Query) As(id string) *Query {
+	return q.with(&GraphStatement{&GraphStatement_As{id}})
+}
+
+// Select retreieves previously marked elemets
+func (q *Query) Select(id ...string) *Query {
+	idList := SelectStatement{id}
+	return q.with(&GraphStatement{&GraphStatement_Select{&idList}})
+}
+
+// Count adds a count step to the query
+func (q *Query) Count() *Query {
+	return q.with(&GraphStatement{&GraphStatement_Count{}})
+}
+
+// Render renders the to a map.
+func (q *Query) Render() map[string]interface{} {
+	m := jsonpb.Marshaler{}
+	b := &bytes.Buffer{}
+	m.Marshal(b, q.GraphQuery)
+	out := map[string]interface{}{}
+	json.Unmarshal(b.Bytes(), &out)
+	return out
+}

--- a/aql/util.go
+++ b/aql/util.go
@@ -5,9 +5,7 @@ import (
 	//"log"
 	//"fmt"
 	"context"
-	"encoding/json"
 	"github.com/bmeg/arachne/protoutil"
-	"github.com/golang/protobuf/jsonpb"
 	structpb "github.com/golang/protobuf/ptypes/struct"
 	"google.golang.org/grpc"
 )
@@ -30,14 +28,6 @@ func Connect(address string, write bool) (Client, error) {
 	}
 	editOut := NewEditClient(conn)
 	return Client{queryOut, editOut}, err
-}
-
-// QueryBuilder allows the user to build complex graph queries then serialize
-// them and then execute via GRPC
-type QueryBuilder struct {
-	client QueryClient
-	graph  string
-	query  []*GraphStatement
 }
 
 // GetGraphs lists the graphs
@@ -121,62 +111,9 @@ func (client Client) GetVertex(graph string, id string) (*Vertex, error) {
 	return v, err
 }
 
-// Query initializes a query build for `graph`
-func (client Client) Query(graph string) QueryBuilder {
-	return QueryBuilder{client.QueryC, graph, []*GraphStatement{}}
-}
-
-// V adds a vertex selection step to the query
-func (q QueryBuilder) V(id ...string) QueryBuilder {
-	vlist := protoutil.AsListValue(id)
-	return QueryBuilder{q.client, q.graph, append(q.query, &GraphStatement{&GraphStatement_V{vlist}})}
-}
-
-// E adds a edge selection step to the query
-func (q QueryBuilder) E(id ...string) QueryBuilder {
-	if len(id) > 0 {
-		return QueryBuilder{q.client, q.graph, append(q.query, &GraphStatement{&GraphStatement_E{id[0]}})}
-	}
-	return QueryBuilder{q.client, q.graph, append(q.query, &GraphStatement{&GraphStatement_E{}})}
-}
-
-// Out follows outgoing edges to adjacent vertex
-func (q QueryBuilder) Out(label ...string) QueryBuilder {
-	vlist := protoutil.AsListValue(label)
-	return QueryBuilder{q.client, q.graph, append(q.query, &GraphStatement{&GraphStatement_Out{vlist}})}
-}
-
-// OutEdge moves to outgoing edge
-func (q QueryBuilder) OutEdge(label ...string) QueryBuilder {
-	vlist := protoutil.AsListValue(label)
-	return QueryBuilder{q.client, q.graph, append(q.query, &GraphStatement{&GraphStatement_OutEdge{vlist}})}
-}
-
-// HasLabel filters elements based on label
-func (q QueryBuilder) HasLabel(id ...string) QueryBuilder {
-	idList := protoutil.AsListValue(id)
-	return QueryBuilder{q.client, q.graph, append(q.query, &GraphStatement{&GraphStatement_HasLabel{idList}})}
-}
-
-// As marks current elements with tag
-func (q QueryBuilder) As(id string) QueryBuilder {
-	return QueryBuilder{q.client, q.graph, append(q.query, &GraphStatement{&GraphStatement_As{id}})}
-}
-
-// Select retreieves previously marked elemets
-func (q QueryBuilder) Select(id ...string) QueryBuilder {
-	idList := SelectStatement{id}
-	return QueryBuilder{q.client, q.graph, append(q.query, &GraphStatement{&GraphStatement_Select{&idList}})}
-}
-
-// Count adds a count step to the query
-func (q QueryBuilder) Count() QueryBuilder {
-	return QueryBuilder{q.client, q.graph, append(q.query, &GraphStatement{&GraphStatement_Count{}})}
-}
-
-// Execute takes the current query, and makes RPC call then streams the results
-func (q QueryBuilder) Execute() (chan *ResultRow, error) {
-	tclient, err := q.client.Traversal(context.TODO(), &GraphQuery{q.graph, q.query})
+// Execute executes the given query.
+func (client Client) Execute(q *Query) (chan *ResultRow, error) {
+	tclient, err := client.QueryC.Traversal(context.TODO(), q.GraphQuery)
 	if err != nil {
 		return nil, err
 	}
@@ -188,27 +125,6 @@ func (q QueryBuilder) Execute() (chan *ResultRow, error) {
 		}
 	}()
 	return out, nil
-}
-
-// Run takes current query and executes it, ignoring the results
-func (q QueryBuilder) Run() error {
-	c, err := q.Execute()
-	if err != nil {
-		return err
-	}
-	for range c {
-	}
-	return nil
-}
-
-// Render takes the current query build and renders it to a map
-func (q QueryBuilder) Render() map[string]interface{} {
-	m := jsonpb.Marshaler{}
-	s, _ := m.MarshalToString(&GraphQuery{q.graph, q.query})
-	//fmt.Printf("%s = %s\n", q, s)
-	out := map[string]interface{}{}
-	json.Unmarshal([]byte(s), &out)
-	return out
 }
 
 // GetDataMap obtains data attached to vertex in the form of a map

--- a/cmd/dump/main.go
+++ b/cmd/dump/main.go
@@ -25,7 +25,8 @@ var Cmd = &cobra.Command{
 		}
 		if vertexDump {
 			jm := jsonpb.Marshaler{}
-			elems, err := conn.Query(graph).V().Execute()
+			q := aql.NewQuery(graph).V()
+			elems, err := conn.Execute(q)
 			if err != nil {
 				log.Printf("ERROR: %s", err)
 				return err
@@ -38,7 +39,8 @@ var Cmd = &cobra.Command{
 
 		if edgeDump {
 			jm := jsonpb.Marshaler{}
-			elems, err := conn.Query(graph).E().Execute()
+			q := aql.NewQuery(graph).E()
+			elems, err := conn.Execute(q)
 			if err != nil {
 				log.Printf("ERROR: %s", err)
 				return err

--- a/cmd/info/main.go
+++ b/cmd/info/main.go
@@ -24,11 +24,13 @@ var Cmd = &cobra.Command{
 		}
 		fmt.Printf("Graph: %s\n", args[0])
 
-		res, _ := conn.Query(args[0]).V().Count().Execute()
+		q := aql.NewQuery(args[0]).V().Count()
+		res, _ := conn.Execute(q)
 		for row := range res {
 			fmt.Printf("Vertex Count: %s\n", row)
 		}
-		res, _ = conn.Query(args[0]).E().Count().Execute()
+		q = aql.NewQuery(args[0]).E().Count()
+		res, _ = conn.Execute(q)
 		for row := range res {
 			fmt.Printf("Edge Count: %s\n", row)
 		}

--- a/graphql/handler.go
+++ b/graphql/handler.go
@@ -36,7 +36,8 @@ func (gh *Handler) ServeHTTP(writer http.ResponseWriter, request *http.Request) 
 
 func getObjects(client aql.Client, gqlDB string) map[string]map[string]interface{} {
 	out := map[string]map[string]interface{}{}
-	results, _ := client.Query(gqlDB).V().HasLabel("Object").Execute()
+	q := aql.NewQuery(gqlDB).V().HasLabel("Object")
+	results, _ := client.Execute(q)
 	for elem := range results {
 		d := elem.GetValue().GetVertex().GetDataMap()
 		out[elem.GetValue().GetVertex().Gid] = d
@@ -46,7 +47,8 @@ func getObjects(client aql.Client, gqlDB string) map[string]map[string]interface
 
 func getQueries(client aql.Client, gqlDB string) map[string]map[string]interface{} {
 	out := map[string]map[string]interface{}{}
-	results, _ := client.Query(gqlDB).V().HasLabel("Query").Execute()
+	q := aql.NewQuery(gqlDB).V().HasLabel("Object")
+	results, _ := client.Execute(q)
 	for elem := range results {
 		d := elem.GetValue().GetVertex().GetDataMap()
 		out[elem.GetValue().GetVertex().Gid] = d
@@ -56,7 +58,8 @@ func getQueries(client aql.Client, gqlDB string) map[string]map[string]interface
 
 func getQueryFields(client aql.Client, gqlDB string, queryGID string) map[string]string {
 	out := map[string]string{}
-	results, _ := client.Query(gqlDB).V(queryGID).OutEdge("field").As("a").Out().As("b").Select("a", "b").Execute()
+	q := aql.NewQuery(gqlDB).V(queryGID).OutEdge("field").As("a").Out().As("b").Select("a", "b")
+	results, _ := client.Execute(q)
 	for elem := range results {
 		fieldName := elem.GetRow()[0].GetEdge().GetProperty("name").(string)
 		fieldObj := elem.GetRow()[1].GetVertex().Gid
@@ -67,7 +70,8 @@ func getQueryFields(client aql.Client, gqlDB string, queryGID string) map[string
 
 func getObjectFields(client aql.Client, gqlDB string, queryGID string) map[string]string {
 	out := map[string]string{}
-	results, _ := client.Query(gqlDB).V(queryGID).OutEdge("field").As("a").Out().As("b").Select("a", "b").Execute()
+	q := aql.NewQuery(gqlDB).V(queryGID).OutEdge("field").As("a").Out().As("b").Select("a", "b")
+	results, _ := client.Execute(q)
 	for elem := range results {
 		fieldName := elem.GetRow()[0].GetEdge().GetProperty("name").(string)
 		fieldObj := elem.GetRow()[1].GetVertex().Gid
@@ -113,7 +117,8 @@ func buildGraphQLSchema(client aql.Client, gqlDB string) *graphql.Schema {
 				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
 					srcMap := p.Source.(map[string]interface{})
 					srcGid := srcMap["__gid"].(string)
-					result, _ := client.Query(dataGraph).V(srcGid).Out(edgeName).Execute()
+					q := aql.NewQuery(dataGraph).V(srcGid).Out(edgeName)
+					result, _ := client.Execute(q)
 					out := []interface{}{}
 					for r := range result {
 						i := r.GetValue().GetVertex().GetDataMap()


### PR DESCRIPTION
Separates query building from the client. The separation of concerns is easier to understand, and it also allows queries to be created, built, validated, reused, exported, etc. without being tied to a specific client (or even needing to create one).