### PR TITLE
aql: improved Query

### DIFF
--- a/aql/query.go
+++ b/aql/query.go
@@ -1,33 +1,34 @@
 package aql
 
 import (
-	"bytes"
-	"encoding/json"
+	"fmt"
 	"github.com/bmeg/arachne/protoutil"
-	"github.com/golang/protobuf/jsonpb"
+	"strings"
 )
+
+func V(ids ...string) *Query {
+	return NewQuery().V(ids...)
+}
+
+func E(ids ...string) *Query {
+	return NewQuery().E(ids...)
+}
+
+func NewQuery() *Query {
+	return &Query{}
+}
 
 // Query helps build graph queries.
 type Query struct {
-	*GraphQuery
-}
-
-// NewQuery returns a new query object.
-func NewQuery(graph string) *Query {
-	return &Query{
-		&GraphQuery{
-			Graph: graph,
-		},
-	}
+	Statements []*GraphStatement
 }
 
 func (q *Query) with(st *GraphStatement) *Query {
-	nq := NewQuery(q.GraphQuery.Graph)
-	nq.GraphQuery.Query = make([]*GraphStatement, len(q.GraphQuery.Query)+1)
-	for i := range q.GraphQuery.Query {
-		nq.GraphQuery.Query[i] = q.GraphQuery.Query[i]
+	nq := &Query{
+		Statements: make([]*GraphStatement, len(q.Statements)),
 	}
-	nq.GraphQuery.Query[len(q.GraphQuery.Query)] = st
+	copy(nq.Statements, q.Statements)
+	nq.Statements = append(nq.Statements, st)
 	return nq
 }
 
@@ -38,11 +39,23 @@ func (q *Query) V(id ...string) *Query {
 }
 
 // E adds a edge selection step to the query
-func (q *Query) E(id ...string) *Query {
-	if len(id) > 0 {
-		return q.with(&GraphStatement{&GraphStatement_E{id[0]}})
+func (q *Query) E(ids ...string) *Query {
+	if len(ids) > 0 {
+		return q.with(&GraphStatement{&GraphStatement_E{ids[0]}})
 	}
 	return q.with(&GraphStatement{&GraphStatement_E{}})
+}
+
+// In follows incoming edges to adjacent vertex
+func (q *Query) In(label ...string) *Query {
+	vlist := protoutil.AsListValue(label)
+	return q.with(&GraphStatement{&GraphStatement_In{vlist}})
+}
+
+// InEdge moves to incoming edge
+func (q *Query) InEdge(label ...string) *Query {
+	vlist := protoutil.AsListValue(label)
+	return q.with(&GraphStatement{&GraphStatement_InEdge{vlist}})
 }
 
 // Out follows outgoing edges to adjacent vertex
@@ -63,6 +76,20 @@ func (q *Query) HasLabel(id ...string) *Query {
 	return q.with(&GraphStatement{&GraphStatement_HasLabel{idList}})
 }
 
+func (q *Query) Has(key string, value ...string) *Query {
+	return q.with(&GraphStatement{&GraphStatement_Has{
+		&HasStatement{key, value}}})
+}
+
+func (q *Query) HasID(id ...string) *Query {
+	idList := protoutil.AsListValue(id)
+	return q.with(&GraphStatement{&GraphStatement_HasId{idList}})
+}
+
+func (q *Query) Limit(c int64) *Query {
+	return q.with(&GraphStatement{&GraphStatement_Limit{c}})
+}
+
 // As marks current elements with tag
 func (q *Query) As(id string) *Query {
 	return q.with(&GraphStatement{&GraphStatement_As{id}})
@@ -74,17 +101,112 @@ func (q *Query) Select(id ...string) *Query {
 	return q.with(&GraphStatement{&GraphStatement_Select{&idList}})
 }
 
+func (q *Query) Values(keys ...string) *Query {
+	idList := SelectStatement{keys}
+	return q.with(&GraphStatement{&GraphStatement_Values{&idList}})
+}
+
+func (q *Query) Match(qs ...*Query) *Query {
+	queries := []*GraphQuery{}
+	for _, q := range qs {
+		queries = append(queries, &GraphQuery{
+			Query: q.Statements,
+		})
+	}
+	set := &GraphQuerySet{queries}
+	return q.with(&GraphStatement{&GraphStatement_Match{set}})
+}
+
 // Count adds a count step to the query
 func (q *Query) Count() *Query {
 	return q.with(&GraphStatement{&GraphStatement_Count{}})
 }
 
-// Render renders the to a map.
-func (q *Query) Render() map[string]interface{} {
-	m := jsonpb.Marshaler{}
-	b := &bytes.Buffer{}
-	m.Marshal(b, q.GraphQuery)
-	out := map[string]interface{}{}
-	json.Unmarshal(b.Bytes(), &out)
-	return out
+func (q *Query) String() string {
+	parts := []string{}
+	add := func(name string, x ...string) {
+		args := strings.Join(x, ", ")
+		parts = append(parts, fmt.Sprintf("%s(%s)", name, args))
+	}
+
+	for _, gs := range q.Statements {
+		switch stmt := gs.GetStatement().(type) {
+		case *GraphStatement_V:
+			ids := protoutil.AsStringList(stmt.V)
+			add("V", ids...)
+
+		case *GraphStatement_E:
+			add("E", stmt.E)
+
+		case *GraphStatement_Has:
+			args := []string{stmt.Has.Key}
+			args = append(args, stmt.Has.Within...)
+			add("Has", args...)
+
+		case *GraphStatement_HasLabel:
+			ids := protoutil.AsStringList(stmt.HasLabel)
+			add("HasLabel", ids...)
+
+		case *GraphStatement_HasId:
+			ids := protoutil.AsStringList(stmt.HasId)
+			add("HasId", ids...)
+
+		case *GraphStatement_In:
+			ids := protoutil.AsStringList(stmt.In)
+			add("In", ids...)
+
+		case *GraphStatement_Out:
+			ids := protoutil.AsStringList(stmt.Out)
+			add("Out", ids...)
+
+		case *GraphStatement_Both:
+			ids := protoutil.AsStringList(stmt.Both)
+			add("Both", ids...)
+
+		case *GraphStatement_InEdge:
+			ids := protoutil.AsStringList(stmt.InEdge)
+			add("InEdge", ids...)
+
+		case *GraphStatement_OutEdge:
+			ids := protoutil.AsStringList(stmt.OutEdge)
+			add("OutEdge", ids...)
+
+		case *GraphStatement_BothEdge:
+			ids := protoutil.AsStringList(stmt.BothEdge)
+			add("BothEdge", ids...)
+
+		case *GraphStatement_Limit:
+			add("Limit", fmt.Sprintf("%d", stmt.Limit))
+
+		case *GraphStatement_Count:
+			add("Count")
+
+		case *GraphStatement_GroupCount:
+			add("GroupCount", stmt.GroupCount)
+
+		case *GraphStatement_As:
+			add("As", stmt.As)
+
+		case *GraphStatement_Select:
+			add("Select", stmt.Select.Labels...)
+		case *GraphStatement_Match:
+			add("Match")
+		case *GraphStatement_Values:
+			add("Values")
+
+		case *GraphStatement_Import:
+			add("Import")
+		case *GraphStatement_Map:
+			add("Map")
+		case *GraphStatement_Fold:
+			add("Fold")
+		case *GraphStatement_Filter:
+			add("Filter")
+		case *GraphStatement_FilterValues:
+			add("FilterValues")
+		case *GraphStatement_VertexFromValues:
+			add("VertexFromValues")
+		}
+	}
+	return strings.Join(parts, ".")
 }

--- a/aql/query.go
+++ b/aql/query.go
@@ -6,14 +6,17 @@ import (
 	"strings"
 )
 
+// V starts a new vertex query, short for `NewQuery().V()`.
 func V(ids ...string) *Query {
 	return NewQuery().V(ids...)
 }
 
+// E starts a new vertex query, short for `NewQuery().E()`.
 func E(ids ...string) *Query {
 	return NewQuery().E(ids...)
 }
 
+// NewQuery creates a new Query instance.
 func NewQuery() *Query {
 	return &Query{}
 }
@@ -76,16 +79,19 @@ func (q *Query) HasLabel(id ...string) *Query {
 	return q.with(&GraphStatement{&GraphStatement_HasLabel{idList}})
 }
 
+// Has filters elements based on data properties.
 func (q *Query) Has(key string, value ...string) *Query {
 	return q.with(&GraphStatement{&GraphStatement_Has{
 		&HasStatement{key, value}}})
 }
 
+// HasID filters elements based on element ID.
 func (q *Query) HasID(id ...string) *Query {
 	idList := protoutil.AsListValue(id)
 	return q.with(&GraphStatement{&GraphStatement_HasId{idList}})
 }
 
+// Limit limits the number of results returned.
 func (q *Query) Limit(c int64) *Query {
 	return q.with(&GraphStatement{&GraphStatement_Limit{c}})
 }
@@ -101,11 +107,13 @@ func (q *Query) Select(id ...string) *Query {
 	return q.with(&GraphStatement{&GraphStatement_Select{&idList}})
 }
 
+// Values changes the result to be values from the element data at the given key.
 func (q *Query) Values(keys ...string) *Query {
 	idList := SelectStatement{keys}
 	return q.with(&GraphStatement{&GraphStatement_Values{&idList}})
 }
 
+// Match is used to concatenate multiple queries.
 func (q *Query) Match(qs ...*Query) *Query {
 	queries := []*GraphQuery{}
 	for _, q := range qs {

--- a/aql/util.go
+++ b/aql/util.go
@@ -112,8 +112,11 @@ func (client Client) GetVertex(graph string, id string) (*Vertex, error) {
 }
 
 // Execute executes the given query.
-func (client Client) Execute(q *Query) (chan *ResultRow, error) {
-	tclient, err := client.QueryC.Traversal(context.TODO(), q.GraphQuery)
+func (client Client) Execute(graph string, q *Query) (chan *ResultRow, error) {
+	tclient, err := client.QueryC.Traversal(context.TODO(), &GraphQuery{
+		Graph: graph,
+		Query: q.Statements,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/dump/main.go
+++ b/cmd/dump/main.go
@@ -25,8 +25,8 @@ var Cmd = &cobra.Command{
 		}
 		if vertexDump {
 			jm := jsonpb.Marshaler{}
-			q := aql.NewQuery(graph).V()
-			elems, err := conn.Execute(q)
+			q := aql.V()
+			elems, err := conn.Execute(graph, q)
 			if err != nil {
 				log.Printf("ERROR: %s", err)
 				return err
@@ -39,8 +39,8 @@ var Cmd = &cobra.Command{
 
 		if edgeDump {
 			jm := jsonpb.Marshaler{}
-			q := aql.NewQuery(graph).E()
-			elems, err := conn.Execute(q)
+			q := aql.E()
+			elems, err := conn.Execute(graph, q)
 			if err != nil {
 				log.Printf("ERROR: %s", err)
 				return err

--- a/cmd/info/main.go
+++ b/cmd/info/main.go
@@ -24,13 +24,13 @@ var Cmd = &cobra.Command{
 		}
 		fmt.Printf("Graph: %s\n", args[0])
 
-		q := aql.NewQuery(args[0]).V().Count()
-		res, _ := conn.Execute(q)
+		q := aql.V().Count()
+		res, _ := conn.Execute(args[0], q)
 		for row := range res {
 			fmt.Printf("Vertex Count: %s\n", row)
 		}
-		q = aql.NewQuery(args[0]).E().Count()
-		res, _ = conn.Execute(q)
+		q = aql.E().Count()
+		res, _ = conn.Execute(args[0], q)
 		for row := range res {
 			fmt.Printf("Edge Count: %s\n", row)
 		}

--- a/graphql/handler.go
+++ b/graphql/handler.go
@@ -36,8 +36,8 @@ func (gh *Handler) ServeHTTP(writer http.ResponseWriter, request *http.Request) 
 
 func getObjects(client aql.Client, gqlDB string) map[string]map[string]interface{} {
 	out := map[string]map[string]interface{}{}
-	q := aql.NewQuery(gqlDB).V().HasLabel("Object")
-	results, _ := client.Execute(q)
+	q := aql.V().HasLabel("Object")
+	results, _ := client.Execute(gqlDB, q)
 	for elem := range results {
 		d := elem.GetValue().GetVertex().GetDataMap()
 		out[elem.GetValue().GetVertex().Gid] = d
@@ -47,8 +47,8 @@ func getObjects(client aql.Client, gqlDB string) map[string]map[string]interface
 
 func getQueries(client aql.Client, gqlDB string) map[string]map[string]interface{} {
 	out := map[string]map[string]interface{}{}
-	q := aql.NewQuery(gqlDB).V().HasLabel("Object")
-	results, _ := client.Execute(q)
+	q := aql.V().HasLabel("Object")
+	results, _ := client.Execute(gqlDB, q)
 	for elem := range results {
 		d := elem.GetValue().GetVertex().GetDataMap()
 		out[elem.GetValue().GetVertex().Gid] = d
@@ -58,8 +58,8 @@ func getQueries(client aql.Client, gqlDB string) map[string]map[string]interface
 
 func getQueryFields(client aql.Client, gqlDB string, queryGID string) map[string]string {
 	out := map[string]string{}
-	q := aql.NewQuery(gqlDB).V(queryGID).OutEdge("field").As("a").Out().As("b").Select("a", "b")
-	results, _ := client.Execute(q)
+	q := aql.V(queryGID).OutEdge("field").As("a").Out().As("b").Select("a", "b")
+	results, _ := client.Execute(gqlDB, q)
 	for elem := range results {
 		fieldName := elem.GetRow()[0].GetEdge().GetProperty("name").(string)
 		fieldObj := elem.GetRow()[1].GetVertex().Gid
@@ -70,8 +70,8 @@ func getQueryFields(client aql.Client, gqlDB string, queryGID string) map[string
 
 func getObjectFields(client aql.Client, gqlDB string, queryGID string) map[string]string {
 	out := map[string]string{}
-	q := aql.NewQuery(gqlDB).V(queryGID).OutEdge("field").As("a").Out().As("b").Select("a", "b")
-	results, _ := client.Execute(q)
+	q := aql.V(queryGID).OutEdge("field").As("a").Out().As("b").Select("a", "b")
+	results, _ := client.Execute(gqlDB, q)
 	for elem := range results {
 		fieldName := elem.GetRow()[0].GetEdge().GetProperty("name").(string)
 		fieldObj := elem.GetRow()[1].GetVertex().Gid
@@ -117,8 +117,8 @@ func buildGraphQLSchema(client aql.Client, gqlDB string) *graphql.Schema {
 				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
 					srcMap := p.Source.(map[string]interface{})
 					srcGid := srcMap["__gid"].(string)
-					q := aql.NewQuery(dataGraph).V(srcGid).Out(edgeName)
-					result, _ := client.Execute(q)
+					q := aql.V(srcGid).Out(edgeName)
+					result, _ := client.Execute(dataGraph, q)
 					out := []interface{}{}
 					for r := range result {
 						i := r.GetValue().GetVertex().GetDataMap()

--- a/protoutil/protoutil.go
+++ b/protoutil/protoutil.go
@@ -85,7 +85,7 @@ func UnWrapValue(value *structpb.Value) interface{} {
 		return out
 	} else if v, ok := value.Kind.(*structpb.Value_BoolValue); ok {
 		return v.BoolValue
-	} else if v, ok := value.Kind.(*structpb.Value_NullValue); ok {
+	} else if _, ok := value.Kind.(*structpb.Value_NullValue); ok {
 		return nil
 	}
 	log.Printf("unwrap unknown data type: %T", value.Kind)


### PR DESCRIPTION
Adds a few missing methods. Adds a String() method which prints a `V().Has()....etc` style string, great for debugging. Also separates the graph ID from the query, so queries could exist apart from a graph instance.