### PR TITLE
Aql python bug fixes

### DIFF
--- a/aql/python/aql/query.py
+++ b/aql/python/aql/query.py
@@ -234,7 +234,7 @@ class Query:
                 elif "aggregations" in d:
                     yield AttrDict(d["aggregations"]["aggregations"])
                 elif "selections" in d:
-                    d = AttrDict(d["selections"]["selections"])
+                    d = d["selections"]["selections"]
                     for k in d:
                         if "vertex" in d[k]:
                             d[k] = d[k]["vertex"]
@@ -242,11 +242,14 @@ class Query:
                             d[k] = d[k]["edge"]
                     yield AttrDict(d)
                 elif "render" in d:
+                    if isinstance(d["render"], dict):
                         yield AttrDict(d["render"])
+                    else:
+                        yield d["render"]
                 elif "count" in d:
-                        yield AttrDict(d)
-                else:
                     yield AttrDict(d)
+                else:
+                    yield d
             except ValueError as e:
                 print("Can't decode: %s" % (result), file=sys.stderr)
                 raise e
@@ -267,12 +270,15 @@ class Query:
 class AttrDict(object):
 
     def __init__(self, data):
-        for k in data:
-            v = data[k]
-            if isinstance(v, dict):
-                self.__dict__[k] = self.__class__(v)
-            else:
-                self.__dict__[k] = v
+        if isinstance(data, dict):
+            for k in data:
+                v = data[k]
+                if isinstance(v, dict):
+                    self.__dict__[k] = self.__class__(v)
+                else:
+                    self.__dict__[k] = v
+        else:
+            raise TypeError("AttrDict expects a dict in __init__")
 
     def __getattr__(self, k):
         try:

--- a/conformance/tests/ot_fields.py
+++ b/conformance/tests/ot_fields.py
@@ -9,8 +9,16 @@ def test_fields(O):
         u"label": u"",
         u"data": {u"name": u"han"}
     }
-
     resp = O.query().V().fields(["_gid", "name"]).execute()
+    if resp[0] != expected:
+        errors.append("vertex contains unexpected fields: %s" % resp)
+
+    expected = {
+        u"gid": u"vertex1",
+        u"label": u"",
+        u"data": {u"non-existent": None}
+    }
+    resp = O.query().V().fields(["_gid", "non-existent"]).execute()
     if resp[0] != expected:
         errors.append("vertex contains unexpected fields: %s" % resp)
 

--- a/conformance/tests/ot_render.py
+++ b/conformance/tests/ot_render.py
@@ -20,14 +20,38 @@ def test_render(O):
     O.addEdge("6", "3", "created", {"weight": 0.2})
     O.addEdge("4", "5", "created", {"weight": 1.0})
 
-    query = O.query().V().where(aql.eq("$.label", "Person")).render(
+    query = O.query().V().where(aql.eq("_label", "Person")).render(
         {
-            "Name": "$.name",
-            "Age": "$.age"
+            "Name": "name",
+            "Age": "age"
         }
     )
-
     for row in query:
         if 'Age' not in row or "Name" not in row:
             errors.append("Missing fields")
+
+    query = O.query().V().where(aql.eq("_label", "Person")).render(
+        {
+            "Name": "name",
+            "NonExistent": "non-existent"
+        }
+    )
+    for row in query:
+        if 'NonExistent' not in row or "Name" not in row:
+            errors.append("Missing fields")
+
+    query = O.query().V().where(aql.eq("_label", "Person")).render(["name", "age"])
+    for row in query:
+        if not isinstance(row, list):
+            errors.append("unexpected output format")
+        if len(row) != 2:
+            errors.append("Missing fields")
+
+    query = O.query().V().where(aql.eq("_label", "Person")).render(["name", "non-existent"])
+    for row in query:
+        if not isinstance(row, list):
+            errors.append("unexpected output format")
+        if len(row) != 2:
+            errors.append("Missing fields")
+
     return errors

--- a/graphserver/server.go
+++ b/graphserver/server.go
@@ -78,7 +78,10 @@ func (server *ArachneServer) Traversal(query *aql.GraphQuery, queryServer aql.Qu
 	}
 	res := engine.Run(queryServer.Context(), pipeline, server.workDir)
 	for row := range res {
-		queryServer.Send(row)
+		err := queryServer.Send(row)
+		if err != nil {
+			return fmt.Errorf("error sending Traversal result: %v", err)
+		}
 	}
 
 	return nil
@@ -87,7 +90,10 @@ func (server *ArachneServer) Traversal(query *aql.GraphQuery, queryServer aql.Qu
 // GetGraphs returns a list of graphs managed by the driver
 func (server *ArachneServer) GetGraphs(empty *aql.Empty, queryServer aql.Query_GetGraphsServer) error {
 	for _, name := range server.db.GetGraphs() {
-		queryServer.Send(&aql.GraphID{Graph: name})
+		err := queryServer.Send(&aql.GraphID{Graph: name})
+		if err != nil {
+			return fmt.Errorf("error sending GetGraphs result: %v", err)
+		}
 	}
 	return nil
 }
@@ -346,7 +352,10 @@ func (server *ArachneServer) GetIndexList(idx *aql.GraphID, stream aql.Query_Get
 	}
 	res := graph.GetVertexIndexList()
 	for i := range res {
-		stream.Send(&i)
+		err := stream.Send(&i)
+		if err != nil {
+			return fmt.Errorf("error sending GetIndexList result: %v", err)
+		}
 	}
 	return nil
 }

--- a/jsonpath/jsonpath.go
+++ b/jsonpath/jsonpath.go
@@ -144,15 +144,17 @@ func RenderTraveler(traveler *gdbi.Traveler, template interface{}) interface{} {
 	case string:
 		return TravelerPathLookup(traveler, elem)
 	case map[string]interface{}:
-		o := make(map[string]interface{}, len(elem))
+		o := make(map[string]interface{})
 		for k, v := range elem {
-			o[k] = RenderTraveler(traveler, v)
+			val := RenderTraveler(traveler, v)
+			o[k] = val
 		}
 		return o
 	case []interface{}:
 		o := make([]interface{}, len(elem))
 		for i := range elem {
-			o[i] = RenderTraveler(traveler, elem[i])
+			val := RenderTraveler(traveler, elem[i])
+			o[i] = val
 		}
 		return o
 	default:

--- a/protoutil/protoutil.go
+++ b/protoutil/protoutil.go
@@ -111,7 +111,7 @@ func WrapValue(value interface{}) *structpb.Value {
 	case *structpb.Struct:
 		return &structpb.Value{Kind: &structpb.Value_StructValue{StructValue: v}}
 	case nil:
-		return nil
+		return &structpb.Value{Kind: &structpb.Value_NullValue{}}
 	default:
 		log.Printf("wrap unknown data type: %T", value)
 	}


### PR DESCRIPTION
* Fixes bug that prevented list results from `render`
* When a field that doesn't exist is selected using `fields` or `render` the server will return `Null` in the returned JSON document for that key. 