### PR TITLE
Fix `distinct` traversal method behavior

### DIFF
--- a/conformance/tests/ot_distinct.py
+++ b/conformance/tests/ot_distinct.py
@@ -1,3 +1,4 @@
+import aql
 
 
 def test_distinct(O):
@@ -16,23 +17,46 @@ def test_distinct(O):
     O.addVertex("5", "Software", {"name": "ripple", "lang": "java"})
     O.addVertex("3", "Software", {"name": "lop", "lang": "java"})
     O.addVertex("8", "Software", {"name": "funnel", "lang": "go"})
+    O.addVertex("14", "Software", {"name": "arachne", "lang": None})
+
+    O.addEdge("1", "5", "developer", gid="edge1")
+    O.addEdge("7", "5", "developer", gid="edge2")
+    O.addEdge("3", "8", "dependency", gid="edge3")
 
     count = 0
     for i in O.query().V().distinct():
         count += 1
-    if count != 13:
-        errors.append("Distinct %s != %s" % (count, 13))
+    if count != 14:
+        errors.append("Distinct %s != %s" % (count, 14))
 
     count = 0
     for i in O.query().V().distinct("_gid"):
         count += 1
-    if count != 13:
-        errors.append("Distinct %s != %s" % (count, 13))
+    if count != 14:
+        errors.append("Distinct %s != %s" % (count, 14))
 
     count = 0
     for i in O.query().V().distinct("name"):
         count += 1
-    if count != 11:
-        errors.append("Distinct %s != %s" % (count, 11))
+    if count != 12:
+        errors.append("Distinct %s != %s" % (count, 12))
+
+    count = 0
+    for i in O.query().V().distinct("lang"):
+        count += 1
+    if count != 3:
+        errors.append("Distinct %s != %s" % (count, 3))
+
+    count = 0
+    for i in O.query().V().distinct("non-existent-field"):
+        count += 1
+    if count != 0:
+        errors.append("Distinct %s != %s" % (count, 0))
+
+    count = 0
+    for i in O.query().V().where(aql.eq("_label", "Person")).mark("person").out().distinct("$person.name"):
+        count += 1
+    if count != 1:
+        errors.append("Distinct %s != %s" % (count, 1))
 
     return errors

--- a/engine/core/processors.go
+++ b/engine/core/processors.go
@@ -653,12 +653,16 @@ func (g *Distinct) Process(ctx context.Context, man gdbi.Manager, in gdbi.InPipe
 		for t := range in {
 			s := make([][]byte, len(g.vals))
 			for i, v := range g.vals {
-				s[i] = []byte(fmt.Sprintf("%#v", jsonpath.TravelerPathLookup(t, v)))
+				if jsonpath.TravelerPathExists(t, v) {
+					s[i] = []byte(fmt.Sprintf("%#v", jsonpath.TravelerPathLookup(t, v)))
+				}
 			}
 			k := bytes.Join(s, []byte{0x00})
-			if !kv.HasKey(k) {
-				kv.Set(k, []byte{0x01})
-				out <- t
+			if len(k) > 0 {
+				if !kv.HasKey(k) {
+					kv.Set(k, []byte{0x01})
+					out <- t
+				}
 			}
 		}
 	}()

--- a/jsonpath/jsonpath.go
+++ b/jsonpath/jsonpath.go
@@ -33,7 +33,7 @@ func GetNamespace(path string) string {
 // Json path within the document referenced by the namespace
 //
 // Example:
-// GetJSONPath("$gene.symbol.ensembl") returns "$.data.symbol.ensembl"
+// GetJSONPath("gene.symbol.ensembl") returns "$.data.symbol.ensembl"
 func GetJSONPath(path string) string {
 	parts := strings.Split(path, ".")
 	if strings.HasPrefix(parts[0], "$") {
@@ -102,7 +102,7 @@ func GetDoc(traveler *gdbi.Traveler, namespace string) map[string]interface{} {
 	return tmap
 }
 
-// TravelerPathLookup gets the value of a field in a Travler
+// TravelerPathLookup gets the value of a field in the given Traveler
 //
 // Example for a traveler containing:
 // {
@@ -136,6 +136,21 @@ func TravelerPathLookup(traveler *gdbi.Traveler, path string) interface{} {
 		return nil
 	}
 	return res
+}
+
+// TravelerPathExists returns true if the field exists in the given Traveler
+func TravelerPathExists(traveler *gdbi.Traveler, path string) bool {
+	namespace := GetNamespace(path)
+	field := GetJSONPath(path)
+	if field == "" {
+		return false
+	}
+	doc := GetDoc(traveler, namespace)
+	_, err := jsonpath.JsonPathLookup(doc, field)
+	if err != nil {
+		return false
+	}
+	return true
 }
 
 // RenderTraveler takes a template and fills in the values using the data structure


### PR DESCRIPTION
Selected fields must exist for the traveler to be considered part of the unique set. 