### PR TITLE
aql/python: add some debugging info to queries

### DIFF
--- a/aql/python/aql/util.py
+++ b/aql/python/aql/util.py
@@ -100,7 +100,7 @@ class AttrDict(object):
 
 
 class Rate:
-    def __init__(self, logger: logging.Logger, report_every: int = 100):
+    def __init__(self, logger, report_every=100):
         self.i = 0
         self.start = None
         self.first = None

--- a/aql/python/aql/util.py
+++ b/aql/python/aql/util.py
@@ -1,7 +1,144 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
+import logging
+
+from datetime import datetime
 from requests import HTTPError
 from requests.compat import urlparse, urlunparse
+
+
+class AttrDict(object):
+
+    def __init__(self, data):
+        if isinstance(data, dict):
+            for k in data:
+                v = data[k]
+                if isinstance(v, dict):
+                    self.__dict__[k] = self.__class__(v)
+                else:
+                    self.__dict__[k] = v
+        else:
+            raise TypeError("AttrDict expects a dict in __init__")
+
+    def __getattr__(self, k):
+        try:
+            return self.__dict__[k]
+        except KeyError:
+            raise AttributeError(
+                "%s has no attribute %s" % (self.__class__.__name__, k)
+            )
+
+    def __setattr__(self, k, v):
+        if isinstance(v, dict):
+            self.__dict__[k] = self.__class__(v)
+        else:
+            self.__dict__[k] = v
+
+    def __delattr__(self, k):
+        try:
+            del self.__dict__[k]
+        except KeyError:
+            raise AttributeError(
+                "%s has no attribute %s" % (self.__class__.__name__, k)
+            )
+
+    def __getitem__(self, k):
+        return self.__getattr__(k)
+
+    def __setitem__(self, k, v):
+        return self.__setattr__(k, v)
+
+    def __delitem__(self, k):
+        return self.__delattr__(k)
+
+    def __eq__(self, other):
+        if isinstance(other, AttrDict):
+            return other.to_dict() == self.to_dict()
+        return other == self.to_dict()
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __repr__(self):
+        attrs = self.to_dict()
+        return '<%s(%s)>' % (self.__class__.__name__, attrs)
+
+    def __str__(self):
+        return self.__repr__()
+
+    def __iter__(self):
+        return iter(self.to_dict())
+
+    def __len__(self):
+        return len(self.to_dict())
+
+    def items(self):
+        for k, v in self.to_dict().items():
+            yield k, v
+
+    def keys(self):
+        for k in self.to_dict().keys():
+            yield k
+
+    def to_dict(self):
+        attrs = {}
+        for a in self.__dict__:
+            if not a.startswith('__') and not callable(getattr(self, a)):
+                val = getattr(self, a)
+                if isinstance(val, dict):
+                    for k in val:
+                        if isinstance(val[k], AttrDict):
+                            attrs[a][k] = val[k].to_dict()
+                        else:
+                            attrs[a] = val
+                            break
+                elif isinstance(val, AttrDict):
+                    attrs[a] = val.to_dict()
+                else:
+                    attrs[a] = val
+        return attrs
+
+
+class Rate:
+    def __init__(self, logger: logging.Logger, report_every: int = 100):
+        self.i = 0
+        self.start = None
+        self.first = None
+        self.report_every = report_every
+        self.logger = logger
+
+    def close(self):
+        if self.i == 0:
+            return
+
+        self.log()
+        dt = datetime.now() - self.first
+        m = "total: {0:,} results processed in {1:,d} seconds".format(
+            self.i,
+            int(dt.total_seconds())
+        )
+        self.logger.info(m)
+
+    def log(self):
+        if self.i == 0:
+            return
+
+        dt = datetime.now() - self.start
+        self.start = datetime.now()
+        rate = self.report_every / dt.total_seconds()
+        m = "rate: {0:,} results processed ({1:,d}/sec)".format(self.i,
+                                                                int(rate))
+        self.logger.debug(m)
+
+    def tick(self):
+        if self.start is None:
+            self.start = datetime.now()
+            self.first = self.start
+
+        self.i += 1
+
+        if self.i % self.report_every == 0:
+            self.log()
 
 
 def process_url(url):


### PR DESCRIPTION
Addresses #129 on the client side. The query described in the issue is returned in a similar timeframe using either the python client or curl.

* Sets chunk_size to None in iter_lines method on response object. 
  * chunk_size must be of type int or None. A value of None will function differently depending on the value of stream. stream=True will read data as it arrives in whatever size the chunks are received. If stream=False, data is returned as a single chunk. http://docs.python-requests.org/en/master/api/#requests.Response.iter_content
* Add debug logging to execute. See below. `<Query instance>.execute(debug=True)`
```
[DEBUG]    2018-08-01 10:50:13,692    POST http://arachne.compbio.ohsu.edu/v1/graph/bmeg/query
[DEBUG]    2018-08-01 10:50:13,694    BODY {"query": [{"v": []}, {"where": {"condition": {"key": "_label", "value": "Individual", "condition": "EQ"}}}, {"where": {"and": {"expressions": [{"condition": {"key": "source", "value": "tcga", "condition": "EQ"}}, {"condition": {"key": "disease_code", "value": "BRCA", "condition": "EQ"}}]}}}, {"in": ["sampleOf"]}, {"mark": "a"}, {"in": ["expressionFor"]}, {"render": ["$a.name", "$.expressions"]}]}
[DEBUG]    2018-08-01 10:50:13,695    STATUS CODE 200
[DEBUG]    2018-08-01 10:50:46,753    rate: 100 results processed (3/sec)
[DEBUG]    2018-08-01 10:51:17,131    rate: 200 results processed (3/sec)
[DEBUG]    2018-08-01 10:51:44,909    rate: 300 results processed (3/sec)
[DEBUG]    2018-08-01 10:52:11,921    rate: 400 results processed (3/sec)
[DEBUG]    2018-08-01 10:52:38,045    rate: 500 results processed (3/sec)
[DEBUG]    2018-08-01 10:53:03,918    rate: 600 results processed (3/sec)
[DEBUG]    2018-08-01 10:53:30,019    rate: 700 results processed (3/sec)
[DEBUG]    2018-08-01 10:53:56,306    rate: 800 results processed (3/sec)
[DEBUG]    2018-08-01 10:54:22,707    rate: 900 results processed (3/sec)
[DEBUG]    2018-08-01 10:54:48,587    rate: 1,000 results processed (3/sec)
[DEBUG]    2018-08-01 10:55:14,919    rate: 1,100 results processed (3/sec)
[DEBUG]    2018-08-01 10:55:19,348    rate: 1,116 results processed (22/sec)
[INFO]    2018-08-01 10:55:19,349    total: 1,116 results processed in 305 seconds
```
